### PR TITLE
Add schema tu use secret in config form

### DIFF
--- a/zigbee2mqttassistant-dev/config.json
+++ b/zigbee2mqttassistant-dev/config.json
@@ -20,9 +20,18 @@
     },
     "schema": {
         "settings": {
+            "basetopic": "str?",
+            "homeassistantdiscoverybasetopic": "str?",
             "mqttserver": "str",
+            "mqttsecure":"str?",
+            "mqttport": "int?",
             "mqttusername": "str",
-            "mqttpassword": "password"
+            "mqttpassword": "password",
+            "lowbatterythreshold": "int?",
+            "allowjointimeout": "int?",
+            "autosetlastseen": "bool?",
+            "devicespollingschedule": "str?",
+            "networkscanschedule": "str?"
         }
     },
     "ports": {

--- a/zigbee2mqttassistant-dev/config.json
+++ b/zigbee2mqttassistant-dev/config.json
@@ -1,1 +1,40 @@
-{"name":"zigbee2mqttassistant-dev","version":"0.3.141","slug":"zigbee2mqttassistant-dev","description":"Zigbee2Mqtt Assistant - GUI for Zigbee2Mqtt - THIS IS THE DEV BRANCH.","url":"https://github.com/yllibed/Zigbee2MqttAssistant","startup":"application","webui":"http://[HOST]:[PORT:80]/","arch":["amd64","armv7"],"boot":"auto","options":{"settings":{"mqttserver":"addon_core_mosquitto","mqttusername":"","mqttpassword":""}},"schema":false,"ports":{"80/tcp":null},"ports_description":{"80/tcp":"GUI http access (not required for HASS.IO ingress)"},"image":"carldebilly/zigbee2mqttassistant","ingress":true,"ingress_port":80,"panel_icon":"mdi:mixcloud","panel_title":"Zigbee2Mqtt","panel_admin":true}
+{
+    "name": "zigbee2mqttassistant-dev",
+    "version": "0.3.141",
+    "slug": "zigbee2mqttassistant-dev",
+    "description": "Zigbee2Mqtt Assistant - GUI for Zigbee2Mqtt - THIS IS THE DEV BRANCH.",
+    "url": "https://github.com/yllibed/Zigbee2MqttAssistant",
+    "startup": "application",
+    "webui": "http://[HOST]:[PORT:80]/",
+    "arch": [
+        "amd64",
+        "armv7"
+    ],
+    "boot": "auto",
+    "options": {
+        "settings": {
+            "mqttserver": "addon_core_mosquitto",
+            "mqttusername": "",
+            "mqttpassword": ""
+        }
+    },
+    "schema": {
+        "settings": {
+            "mqttserver": "str",
+            "mqttusername": "str",
+            "mqttpassword": "password"
+        }
+    },
+    "ports": {
+        "80/tcp": null
+    },
+    "ports_description": {
+        "80/tcp": "GUI http access (not required for HASS.IO ingress)"
+    },
+    "image": "carldebilly/zigbee2mqttassistant",
+    "ingress": true,
+    "ingress_port": 80,
+    "panel_icon": "mdi:mixcloud",
+    "panel_title": "Zigbee2Mqtt",
+    "panel_admin": true
+}


### PR DESCRIPTION
Hello,

I modified your config.json to have the possibility to use these writing in webform : 
```
settings:
  mqttserver: addon_core_mosquitto
  mqttusername: '!secret mqtt_zigbee'
  mqttpassword: '!secret mqtt_zigbee_password'
```

And home assistant template according to secrets.yaml file in your options.json file.
It's not the best ways because the password is clear in options.json but better than nothing :)

In your container, a warning is still present but I don't know C# to improve that.
And the addon is still working.

```
warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[35]
      No XML encryptor configured. Key {number-and-letter} may be persisted to storage in unencrypted form.
```

Another remark, if you add a README.md in the folder which contains the config.json. It'll displayed in the webpage of the supervisor. But be careful. I tried your readme and the display is bad.

Thx for your great addons.

Sorry for my language, it's not my native.

Syncerely,
Turiok