### PR TITLE
Allow users to configure the zigbee2mqttassistant settings with the latest home asisstant releases

### DIFF
--- a/zigbee2mqttassistant-dev/config.json
+++ b/zigbee2mqttassistant-dev/config.json
@@ -44,7 +44,8 @@
         "autosetlastseen": "bool?",
         "devicespollingschedule": "str?",
         "networkscanschedule": "str?"
-      },
+      }
+    },
     "ports":{
        "80/tcp":null
     },

--- a/zigbee2mqttassistant-dev/config.json
+++ b/zigbee2mqttassistant-dev/config.json
@@ -1,1 +1,60 @@
-{"name":"zigbee2mqttassistant-dev","version":"0.3.178","slug":"zigbee2mqttassistant-dev","description":"Zigbee2Mqtt Assistant - GUI for Zigbee2Mqtt - THIS IS THE DEV BRANCH.","url":"https://github.com/yllibed/Zigbee2MqttAssistant","startup":"application","webui":"http://[HOST]:[PORT:80]/","arch":["amd64","armv7"],"boot":"auto","options":{"settings":{"mqttserver":"addon_core_mosquitto","mqttusername":"","mqttpassword":""}},"schema":false,"ports":{"80/tcp":null},"ports_description":{"80/tcp":"GUI http access (not required for HASS.IO ingress)"},"image":"carldebilly/zigbee2mqttassistant","ingress":true,"ingress_port":80,"panel_icon":"mdi:zigbee","panel_title":"Zigbee2Mqtt","panel_admin":true}
+{
+    "name":"zigbee2mqttassistant-dev",
+    "version":"0.3.178",
+    "slug":"zigbee2mqttassistant-dev",
+    "description":"Zigbee2Mqtt Assistant - GUI for Zigbee2Mqtt - THIS IS THE DEV BRANCH.",
+    "url":"https://github.com/yllibed/Zigbee2MqttAssistant",
+    "startup":"application",
+    "webui":"http://[HOST]:[PORT:80]/",
+    "arch":[
+       "amd64",
+       "armv7"
+    ],
+    "map": [
+        "config:rw"
+    ],
+    "boot":"auto",
+    "options":{
+       "settings":{
+          "mqttserver":"addon_core_mosquitto",
+          "mqttport": 1883,
+          "mqttusername":"",
+          "mqttpassword":"",
+          "mqttsecure": false,
+          "basetopic": "zigbee2mqtt",
+          "homeassistantdiscoverybasetopic": "homeassistant",
+          "lowbatterythreshold": 30,
+          "allowjointimeout": 20,
+          "autosetlastseen": false,
+          "devicespollingschedule": "*/12 * * * *",
+          "networkscanschedule": "0 */3 * * *"
+       }
+    },
+    "schema": {
+      "settings": {
+        "mqttserver": "str",
+        "mqttport": "int(0,65535)?",
+        "mqttusername": "str",
+        "mqttpassword": "str",
+        "mqttsecure": "bool?",
+        "basetopic": "str?",
+        "homeassistantdiscoverybasetopic": "str?",
+        "lowbatterythreshold": "int(0,100)?",
+        "allowjointimeout": "int(0)?",
+        "autosetlastseen": "bool?",
+        "devicespollingschedule": "str?",
+        "networkscanschedule": "str?"
+      },
+    "ports":{
+       "80/tcp":null
+    },
+    "ports_description":{
+       "80/tcp":"GUI http access (not required for HASS.IO ingress)"
+    },
+    "image":"carldebilly/zigbee2mqttassistant",
+    "ingress":true,
+    "ingress_port":80,
+    "panel_icon":"mdi:zigbee",
+    "panel_title":"Zigbee2Mqtt",
+    "panel_admin":true
+ }

--- a/zigbee2mqttassistant-dev/config.json
+++ b/zigbee2mqttassistant-dev/config.json
@@ -40,7 +40,7 @@
         "basetopic": "str?",
         "homeassistantdiscoverybasetopic": "str?",
         "lowbatterythreshold": "int(0,100)?",
-        "allowjointimeout": "int(0)?",
+        "allowjointimeout": "int(0,)?",
         "autosetlastseen": "bool?",
         "devicespollingschedule": "str?",
         "networkscanschedule": "str?"

--- a/zigbee2mqttassistant/config.json
+++ b/zigbee2mqttassistant/config.json
@@ -17,15 +17,33 @@
    "options":{
       "settings":{
          "mqttserver":"addon_core_mosquitto",
+         "mqttport": "",
          "mqttusername":"",
-         "mqttpassword":""
+         "mqttpassword":"",
+         "mqttsecure": false,
+         "basetopic": "zigbee2mqtt",
+         "homeassistantdiscoverybasetopic": "homeassistant",
+         "lowbatterythreshold": 30,
+         "allowjointimeout": 20,
+         "autosetlastseen": false,
+         "devicespollingschedule": "*/12 * * * *",
+         "networkscanschedule": "0 */3 * * *"
       }
    },
    "schema": {
     "settings": {
       "mqttserver": "str",
+      "mqttport": "int(0,65535)?",
       "mqttusername": "str",
-      "mqttpassword": "str"
+      "mqttpassword": "str",
+      "mqttsecure": "bool?",
+      "basetopic": "str?",
+      "homeassistantdiscoverybasetopic": "str?",
+      "lowbatterythreshold": "int(0,100)?",
+      "allowjointimeout": "int(0)?",
+      "autosetlastseen": "bool?",
+      "devicespollingschedule": "str?",
+      "networkscanschedule": "str?"
      }
    },
    "ports":{

--- a/zigbee2mqttassistant/config.json
+++ b/zigbee2mqttassistant/config.json
@@ -40,7 +40,7 @@
       "basetopic": "str?",
       "homeassistantdiscoverybasetopic": "str?",
       "lowbatterythreshold": "int(0,100)?",
-      "allowjointimeout": "int(0)?",
+      "allowjointimeout": "int(0,)?",
       "autosetlastseen": "bool?",
       "devicespollingschedule": "str?",
       "networkscanschedule": "str?"


### PR DESCRIPTION
This PR expands upon: [PR #6](https://github.com/yllibed/hassio/pull/6) by adding all possible config values to the schema object and setting an default value where possible.
This change is backwards compatible since none of the new settings are required and exisiting config settings won't get overwritten.
The changes for join timeout, secure connection and basetopic were tested (since I require these settings for my use-case).
